### PR TITLE
Update handleUpload.js

### DIFF
--- a/lib/src/services/uploads/uploads-google.service.js
+++ b/lib/src/services/uploads/uploads-google.service.js
@@ -1,7 +1,7 @@
 // Initializes the `uploads` service on path `/uploads`
 const hooks = require('./uploads.hooks');
 const { Storage } = require('@google-cloud/storage');
-const uuidv4 = require('uuid/v4');
+const { v4: uuidv4 } = require('uuid');
 const debug = require('debug')('feathers-mongoose-casl');
 const { UPLOAD_PUBLIC_FILE_KEY } = require('../../enums');
 

--- a/lib/src/utils/uploadMiddleware/utils/handleUpload.js
+++ b/lib/src/utils/uploadMiddleware/utils/handleUpload.js
@@ -1,5 +1,5 @@
 const { UPLOAD_PUBLIC_FILE_KEY, STORAGE_TYPES } = require('../../../enums');
-const uuidv4 = require('uuid/v4');
+const { v4: uuidv4 } = require('uuid');
 const getFileUrl = require('./getFileUrl');
 
 const handleUpload = async function (params) {


### PR DESCRIPTION
#25 

current:
const uuidv4 = require('uuid/v4');

change to:
const { v4: uuidv4 } = require('uuid');

per the v4.js package ...
  "Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid#deep-requires-now-deprecated for more information.",